### PR TITLE
improve softkeyboard handling

### DIFF
--- a/app/src/main/java/de/stephanlindauer/criticalmaps/Main.java
+++ b/app/src/main/java/de/stephanlindauer/criticalmaps/Main.java
@@ -86,7 +86,7 @@ public class Main extends FragmentActivity implements ActionBar.TabListener {
         viewPager.setAdapter(tabsPagerAdapter);
 
         actionBar.addTab(actionBar.newTab().setText(R.string.section_map).setTabListener(this));
-        actionBar.addTab(actionBar.newTab().setText(R.string.section_chat).setTabListener(this));
+        actionBar.addTab(actionBar.newTab().setText(R.string.section_chat).setTabListener(this).setTag("chat_tab"));
         actionBar.addTab(actionBar.newTab().setText(R.string.section_twitter).setTabListener(this));
         actionBar.addTab(actionBar.newTab().setText(R.string.section_rules).setTabListener(this));
         actionBar.addTab(actionBar.newTab().setText(R.string.section_about).setTabListener(this));
@@ -115,7 +115,6 @@ public class Main extends FragmentActivity implements ActionBar.TabListener {
     @Override
     public void onTabSelected(ActionBar.Tab tab, FragmentTransaction fragmentTransaction) {
         viewPager.setCurrentItem(tab.getPosition());
-        hideKeyBoard();
     }
 
     private void hideKeyBoard() {
@@ -124,12 +123,16 @@ public class Main extends FragmentActivity implements ActionBar.TabListener {
         if (editMessageTextfield == null)
             return;
 
+        editMessageTextfield.clearFocus();
         InputMethodManager inputMethodManager = (InputMethodManager) getSystemService(Context.INPUT_METHOD_SERVICE);
         inputMethodManager.hideSoftInputFromWindow(editMessageTextfield.getWindowToken(), 0);
     }
 
     @Override
     public void onTabUnselected(ActionBar.Tab tab, FragmentTransaction fragmentTransaction) {
+        if("chat_tab".equals(tab.getTag())) {
+            hideKeyBoard();
+        }
     }
 
     @Override

--- a/app/src/main/res/layout/fragment_chat.xml
+++ b/app/src/main/res/layout/fragment_chat.xml
@@ -3,7 +3,10 @@
     android:layout_width="fill_parent"
     android:layout_height="fill_parent"
     android:background="#222"
-    android:orientation="vertical">
+    android:orientation="vertical"
+    android:focusable="true"
+    android:focusableInTouchMode="true"
+    android:descendantFocusability="beforeDescendants">
 
     <TextView
         android:id="@+id/chat_heading"


### PR DESCRIPTION
When the softkeyboard has been opened at least once in the chat fragment,
it needs to be hidden on fragment change since the chat fragment is still
in a "visible" state and the EditText keeps focus. As of now this is done
by hiding the keyboard whenever a new tab is selected. Unfortunately this
doesn't handle the case when the Activity is resumed via notification
since the EditText still gets the focus and therefore the keyboard is
opened again.
This patch works around this by making the parent Layout focusable and
removing focus from the EditText when leaving the chat fragment. Also only
do this when we're leaving the chat fragment.