### PR TITLE
Fix memory leak due to osmbonuspack bug

### DIFF
--- a/app/src/main/java/de/stephanlindauer/criticalmaps/fragments/MapFragment.java
+++ b/app/src/main/java/de/stephanlindauer/criticalmaps/fragments/MapFragment.java
@@ -13,11 +13,9 @@ import android.widget.RelativeLayout;
 import com.squareup.otto.Subscribe;
 
 import org.osmdroid.DefaultResourceProxyImpl;
-import org.osmdroid.bonuspack.overlays.Marker;
 import org.osmdroid.bonuspack.overlays.Polyline;
 import org.osmdroid.util.GeoPoint;
 import org.osmdroid.views.MapView;
-import org.osmdroid.views.overlay.Overlay;
 
 import java.util.ArrayList;
 
@@ -29,6 +27,7 @@ import de.stephanlindauer.criticalmaps.events.NewServerResponseEvent;
 import de.stephanlindauer.criticalmaps.model.OtherUsersLocationModel;
 import de.stephanlindauer.criticalmaps.model.OwnLocationModel;
 import de.stephanlindauer.criticalmaps.model.SternfahrtModel;
+import de.stephanlindauer.criticalmaps.overlays.LocationMarker;
 import de.stephanlindauer.criticalmaps.provider.EventBusProvider;
 import de.stephanlindauer.criticalmaps.service.LocationUpdatesService;
 import de.stephanlindauer.criticalmaps.utils.MapViewUtils;
@@ -132,21 +131,17 @@ public class MapFragment extends Fragment {
         }
 
         for (GeoPoint currentOtherUsersLocation : otherUsersLocationModel.getOtherUsersLocations()) {
-            Marker otherPeoplesMarker = new Marker(mapView, resourceProxy);
+            LocationMarker otherPeoplesMarker = new LocationMarker(mapView, resourceProxy);
             otherPeoplesMarker.setPosition(currentOtherUsersLocation);
-            otherPeoplesMarker.setAnchor(Marker.ANCHOR_CENTER, Marker.ANCHOR_CENTER);
             otherPeoplesMarker.setIcon(locationIcon);
-            otherPeoplesMarker.setInfoWindow(null);
             mapView.getOverlays().add(otherPeoplesMarker);
         }
 
         if (ownLocationModel.ownLocation != null) {
             GeoPoint currentUserLocation = ownLocationModel.ownLocation;
-            Marker ownMarker = new Marker(mapView, resourceProxy);
+            LocationMarker ownMarker = new LocationMarker(mapView, resourceProxy);
             ownMarker.setPosition(currentUserLocation);
-            ownMarker.setAnchor(Marker.ANCHOR_CENTER, Marker.ANCHOR_CENTER);
             ownMarker.setIcon(ownLocationIcon);
-            ownMarker.setInfoWindow(null);
             mapView.getOverlays().add(ownMarker);
         }
 

--- a/app/src/main/java/de/stephanlindauer/criticalmaps/overlays/LocationMarker.java
+++ b/app/src/main/java/de/stephanlindauer/criticalmaps/overlays/LocationMarker.java
@@ -1,0 +1,26 @@
+package de.stephanlindauer.criticalmaps.overlays;
+
+import org.osmdroid.ResourceProxy;
+import org.osmdroid.bonuspack.overlays.Marker;
+import org.osmdroid.views.MapView;
+
+public class LocationMarker extends Marker {
+
+    public LocationMarker(MapView mapView, ResourceProxy resourceProxy) {
+        super(mapView, resourceProxy);
+        setAnchor(Marker.ANCHOR_CENTER, Marker.ANCHOR_CENTER);
+        setInfoWindow(null);
+    }
+
+    // The Marker class holds a static reference to a DefaultInfoWindow instance
+    // which in turn holds a reference to the MapView. Thus it leaks the entire
+    // view hierarchy when the fragment is detached.
+    // Work around this by nulling out static references on detach.
+    // TODO check if osmbonuspack fixed this
+    @Override
+    public void onDetach(MapView mapView) {
+        mDefaultIcon = null;
+        mDefaultInfoWindow = null;
+        super.onDetach(mapView);
+    }
+}


### PR DESCRIPTION
The Marker class holds a static reference to a DefaultInfoWindow instance
which in turn holds a reference to the MapView. Thus it leaks the entire
view hierarchy when the fragment is detached.
Work around this by sub classing marker and implementing Overlay's
onDetach() method to null out the static references there.
Also move common initialization code to the subclass.